### PR TITLE
Add official sa password for Matrix42

### DIFF
--- a/assets/default-credentials.txt
+++ b/assets/default-credentials.txt
@@ -67,6 +67,7 @@ sa:GCSsa5560
 sa:GCSsa5560 
 sa:Hpdsdb000001
 sa:M3d!aP0rtal
+sa:Matrix42
 sa:Matrix42.Empirum
 sa:PCAmerica
 sa:Password123


### PR DESCRIPTION
This adds a new potential password for Matrix42 to the list of default credentials, see <https://help.matrix42.com/010_SUEM/020_UEM/20Client_Management/Installation_and_Configuration/099_Version_21.0/Empirum_21.0_-_Installation_Manual#:~:text=For%20the%20database%20username%2C%20enter,for%20the%20password%2C%20enter%20Matrix42.> for an official reference.